### PR TITLE
Add the 'NET_RAW" capability to support K8S deployments running CRI-O

### DIFF
--- a/internal/mutation/gatewayPodMutator.go
+++ b/internal/mutation/gatewayPodMutator.go
@@ -306,6 +306,7 @@ func (cfg gatewayPodMutatorCfg) GatewayPodMutator(_ context.Context, adReview *k
 					Capabilities: &corev1.Capabilities{
 						Add: []corev1.Capability{
 							"NET_ADMIN",
+							"NET_RAW",
 						},
 						Drop: []corev1.Capability{},
 					},

--- a/internal/mutation/gatewayPodMutator.go
+++ b/internal/mutation/gatewayPodMutator.go
@@ -230,6 +230,7 @@ func (cfg gatewayPodMutatorCfg) GatewayPodMutator(_ context.Context, adReview *k
 					Capabilities: &corev1.Capabilities{
 						Add: []corev1.Capability{
 							"NET_ADMIN",
+							"NET_RAW",
 						},
 						Drop: []corev1.Capability{},
 					},

--- a/internal/mutation/gatewayPodMutator_test.go
+++ b/internal/mutation/gatewayPodMutator_test.go
@@ -135,6 +135,7 @@ func getExpectedPodSpec_gateway(gateway string, DNS string, initImage string, si
 				Capabilities: &corev1.Capabilities{
 					Add: []corev1.Capability{
 						"NET_ADMIN",
+						"NET_RAW",
 					},
 					Drop: []corev1.Capability{},
 				},

--- a/internal/mutation/gatewayPodMutator_test.go
+++ b/internal/mutation/gatewayPodMutator_test.go
@@ -87,6 +87,7 @@ func getExpectedPodSpec_gateway(gateway string, DNS string, initImage string, si
 				Capabilities: &corev1.Capabilities{
 					Add: []corev1.Capability{
 						"NET_ADMIN",
+						"NET_RAW",
 					},
 					Drop: []corev1.Capability{},
 				},


### PR DESCRIPTION
**Description of the change**

On K8S instances running under the CRIO container runtime, adding the `NET_RAW` capability is required in order to be allowed to use ping. In case of the 'gateway-init' sidecar container - which init scripts depends on using `ping` this capability is required in order to achieve a successful init of the container.

**Benefits**

This adds support for K8S installations running under CRIO

**Possible drawbacks**
Adding NET_RAW has the security implication of bypassing the linux TCP stack, making SYN floods easier when talking (D)DoS attacks.

**Further Information**

I have tested this to be working on the following environment:

- Ubuntu 22.04
- K8S v1.24.3
- Calico CNI
- CRI-O Container Runtime


